### PR TITLE
Add customize changeset endpoint tests

### DIFF
--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -52,6 +52,15 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
+	 * Return a WP_Error with an 'illegal' code..
+	 *
+	 * @return WP_Error
+	 */
+	public function __return_error_illegal() {
+		return new WP_Error( 'illegal' );
+	}
+
+	/**
 	 * Test register_routes.
 	 *
 	 * @covers WP_REST_Customize_Changesets_Controller::register_routes()
@@ -604,6 +613,27 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
+	 * Test that update_item() rejects setting the date of a changeset to the past.
+	 */
+	public function test_update_item_not_future_date_with_past_date() {
+		wp_set_current_user( self::$admin_id );
+
+		$manager = new WP_Customize_Manager();
+		$manager->save_changeset_post();
+
+		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request->set_body_params( array(
+			'date_gmt' => strtotime( '-1 week' ),
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'not_future_date', $response );
+		$this->assertSame( $date_before, get_post( $manager->changeset_post_id() )->post_date_gmt );
+	}
+
+	/**
 	 * Test that update_item() rejects scheduling a changeset when it has a past date.
 	 */
 	public function test_update_item_not_future_date_with_future_status() {
@@ -624,6 +654,27 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertErrorResponse( 'not_future_date', $response );
 		$this->assertSame( $status_before, get_post_status( $manager->changeset_post_id() ) );
+	}
+
+	/**
+	 * Test that update_item() rejects setting a the date of an auto-draft changeset.
+	 */
+	public function test_update_item_cannot_supply_date_for_auto_draft_changeset() {
+		wp_set_current_user( self::$admin_id );
+
+		$uuid = wp_generate_uuid4();
+		$manager = new WP_Customize_Manager( array(
+			'changeset_uuid' => $uuid,
+		) );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request->set_body_params( array(
+			'date_gmt' => strtotime( '+1 week' ),
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'cannot_supply_date_for_auto_draft_changeset', $response );
+		$this->assertEmpty( $manager->changeset_post_id() );
 	}
 
 	/**
@@ -745,6 +796,58 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$data = $response->get_data();
 		$this->assertTrue( isset( $data['setting_validities'][ $bad_setting ]['unrecognized'] ) );
+	}
+
+	/**
+	 * Test that using update_item() to transactionally update a changeset fails when settings are invalid.
+	 */
+	public function test_update_item_transaction_fail_setting_validities() {
+		wp_set_current_user( self::$admin_id );
+
+		$illegal_setting = 'foo_illegal';
+		add_filter( "customize_validate_{$illegal_setting}", array( $this, '__return_error_illegal' ) );
+
+		$manager = new WP_Customize_Manager();
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request->set_body_params( array(
+			'customize_changeset_data' => array(
+				$illegal_setting => array(
+					'value' => 'Foo',
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'transaction_fail', $response );
+
+		$error_data = $response->as_error()->get_error_data();
+		$illegal_code = $this->__return_error_illegal()->get_error_code();
+		$this->assertNotEmpty( $error_data['setting_validities'][ $illegal_setting ][ $illegal_code ] );
+	}
+
+	/**
+	 * Test that update_item() reports errors inserting or updating a changeset.
+	 */
+	public function test_update_item_changeset_post_save_failure() {
+		wp_set_current_user( self::$admin_id );
+
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$manager = new WP_Customize_Manager();
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request->set_body_params( array(
+			'status' => 'draft',
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$error_code = 'changeset_post_save_failure';
+
+		$this->assertErrorResponse( $error_code, $response );
+
+		$error_data = $response->as_error()->get_error_data();
+		$this->assertSame( 'empty_content', $error_data[ $error_code ][ $error_code ] );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -125,10 +125,9 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_schema() {
 
-		$request = new WP_REST_Request( 'OPTIONS', '/customize/v1/changesets' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
-		$properties = $data['schema']['properties'];
+		$changeset_controller = new WP_REST_Customize_Changesets_Controller();
+		$schema = $changeset_controller->get_item_schema();
+		$properties = $schema['properties'];
 
 		$this->assertEquals( 7, count( $properties ) );
 
@@ -144,7 +143,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['date_gmt']['arg_options'] );
 
 		$this->assertArrayHasKey( 'settings', $properties ); // Instead of content.
-		$this->assertSame( 'object', $properties['settings'] );
+		$this->assertSame( 'object', $properties['settings']['type'] );
 
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertSame( 'string', $properties['slug']['type'] );

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -144,7 +144,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['date_gmt']['arg_options'] );
 
 		$this->assertArrayHasKey( 'settings', $properties ); // Instead of content.
-		$this->assertSame( 'array', $properties['settings'] );
+		$this->assertSame( 'object', $properties['settings'] );
 
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertSame( 'string', $properties['slug']['type'] );

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -12,32 +12,34 @@
  * @group restapi
  */
 class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controller_TestCase {
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @todo Grant or deny caps to the user rather than assuming that roles do or don't have caps.
+	 *
+	 * @var int
+	 */
+	static $subscriber_id;
 
 	/**
 	 * Admin user ID.
 	 *
+	 * @todo Grant or deny caps to the user rather than assuming that roles do or don't have caps.
+	 *
 	 * @var int
 	 */
-	static $admin_user_id;
+	static $admin_id;
 
 	/**
 	 * Set up before class.
 	 */
-	static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		self::$admin_user_id = self::factory()->user->create( array(
-			'role' => 'administrator',
+	public static function wpSetUpBeforeClass( $factory ) {
+		// Deleted by _delete_all_data() in WP_UnitTestCase::tearDownAfterClass().
+		self::$subscriber_id = $factory->user->create( array(
+			'role' => 'subscriber',
 		) );
-	}
 
-	/**
-	 * Set up.
-	 */
-	public function setUp() {
-		parent::setUp();
-
-		$this->admin_id = $this->factory->user->create( array(
+		self::$admin_id = $factory->user->create( array(
 			'role' => 'administrator',
 		) );
 	}
@@ -51,6 +53,15 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey( '/wp/v2/customize/changesets', $routes );
 		$this->assertArrayHasKey( '/wp/v2/customize/changesets/(?P<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}+)', $routes );
+	}
+
+	/**
+	 * Test (get_)context_param.
+	 *
+	 * @covers WP_REST_Customize_Changesets_Controller::get_context_param()
+	 */
+	public function test_context_param() {
+		$this->markTestIncomplete();
 	}
 
 	/**
@@ -104,7 +115,180 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::delete_item()
 	 */
 	public function test_delete_item() {
-		$this->markTestIncomplete();
+		wp_set_current_user( self::$admin_id );
+
+		$uuid = wp_generate_uuid4();
+
+		$changeset_id = self::factory()->post->create( array(
+			'post_name' => $uuid,
+			'post_type' => 'customize_changeset',
+		) );
+
+		$manager = new \WP_Customize_Manager();
+
+		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request->set_param( 'force', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response->as_error() );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'trash', $data['status'] );
+
+		$this->assertSame( 'trash', get_post_status( $manager->find_changeset_post_id( $uuid ) ) );
+	}
+
+	/**
+	 * Test delete_item() by a user without capabilities.
+	 */
+	public function test_delete_item_without_permission() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$uuid = wp_generate_uuid4();
+
+		$changeset_id = self::factory()->post->create( array(
+			'post_name' => $uuid,
+			'post_type' => 'customize_changeset',
+		) );
+
+		$manager = new \WP_Customize_Manager();
+
+		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request->set_param( 'force', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
+
+		$this->assertNotSame( 'trash', get_post_status( $manager->find_changeset_post_id( $uuid ) ) );
+	}
+
+	/**
+	 * Test delete_item() with `$force = true`.
+	 */
+	public function test_force_delete_item() {
+		wp_set_current_user( self::$admin_id );
+
+		$uuid = wp_generate_uuid4();
+
+		$changeset_id = self::factory()->post->create( array(
+			'post_name' => $uuid,
+			'post_type' => 'customize_changeset',
+		) );
+
+		$manager = new \WP_Customize_Manager();
+
+		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response->as_error() );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['deleted'] );
+		$this->assertNotEmpty( $data['previous'] );
+
+		$this->assertNull( $manager->find_changeset_post_id( $uuid ) );
+	}
+
+
+	/**
+	 * Test delete_item() with `$force = true` by a user without capabilities.
+	 */
+	public function test_force_delete_item_without_permission() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$uuid = wp_generate_uuid4();
+
+		$changeset_id = self::factory()->post->create( array(
+			'post_name' => $uuid,
+			'post_type' => 'customize_changeset',
+		) );
+
+		$manager = new \WP_Customize_Manager();
+
+		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
+		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
+	}
+
+	/**
+	 * Test delete_item() where the item is already in the trash.
+	 */
+	public function test_delete_item_already_trashed() {
+		wp_set_current_user( self::$admin_id );
+
+		$uuid = wp_generate_uuid4();
+
+		$changeset_id = self::factory()->post->create( array(
+			'post_name'   => $uuid,
+			'post_type'   => 'customize_changeset',
+		) );
+
+		$manager = new \WP_Customize_Manager();
+		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request->set_param( 'force', false );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_already_trashed', $response, 410 );
+	}
+
+	/**
+	 * Test delete_item() by a user without capabilities where the item is already in the trash.
+	 */
+	public function test_delete_item_already_trashed_without_permission() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$uuid = wp_generate_uuid4();
+
+		$changeset_id = self::factory()->post->create( array(
+			'post_name'   => $uuid,
+			'post_type'   => 'customize_changeset',
+		) );
+
+		wp_trash_post( $changeset_id );
+
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
+	}
+
+	/**
+	 * Test delete_item with an invalid changeset ID.
+	 */
+	public function test_delete_item_invalid_id() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', wp_generate_uuid4() ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * Test delete_item by a user without capabilities with an invalid changeset ID.
+	 */
+	public function test_delete_item_invalid_id_without_permission() {
+		wp_set_current_user( self::$subscriber_id );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', wp_generate_uuid4() ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 	}
 
 	/**
@@ -113,15 +297,6 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::prepare_item_for_response()
 	 */
 	public function test_prepare_item() {
-		$this->markTestIncomplete();
-	}
-
-	/**
-	 * Test (get_)context_param.
-	 *
-	 * @covers WP_REST_Customize_Changesets_Controller::get_context_param()
-	 */
-	public function test_context_param() {
 		$this->markTestIncomplete();
 	}
 }

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -133,29 +133,29 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertEquals( 7, count( $properties ) );
 
 		$this->assertArrayHasKey( 'author', $properties );
-		$this->assertSame( 'integer', $properties['author'] );
+		$this->assertSame( 'integer', $properties['author']['type'] );
 
 		$this->assertArrayHasKey( 'date', $properties );
-		$this->assertSame( 'string', $properties['date'] );
+		$this->assertSame( 'string', $properties['date']['type'] );
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['date']['arg_options'] );
 
 		$this->assertArrayHasKey( 'date_gmt', $properties );
-		$this->assertSame( 'string', $properties['date_gmt'] );
+		$this->assertSame( 'string', $properties['date_gmt']['type'] );
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['date_gmt']['arg_options'] );
 
 		$this->assertArrayHasKey( 'settings', $properties ); // Instead of content.
 		$this->assertSame( 'array', $properties['settings'] );
 
 		$this->assertArrayHasKey( 'slug', $properties );
-		$this->assertSame( 'string', $properties['slug'] );
+		$this->assertSame( 'string', $properties['slug']['type'] );
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['slug']['arg_options'] );
 
 		$this->assertArrayHasKey( 'status', $properties );
-		$this->assertSame( 'string', $properties['status'] );
+		$this->assertSame( 'string', $properties['status']['type'] );
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['status']['arg_options'] );
 
 		$this->assertArrayHasKey( 'title', $properties );
-		$this->assertSame( 'string', $properties['title'] );
+		$this->assertSame( 'string', $properties['title']['type'] );
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['title']['arg_options'] );
 	}
 
@@ -264,16 +264,17 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			'post_type' => 'customize_changeset',
 			'post_name' => wp_generate_uuid4(),
 			'post_status' => 'auto-draft',
+			'post_content' => '{}',
 		) );
 		$this->factory()->post->create( array(
 			'post_type' => 'customize_changeset',
 			'post_name' => wp_generate_uuid4(),
 			'post_status' => 'auto-draft',
+			'post_content' => '{}',
 		) );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets' ) );
 		$response = $this->server->dispatch( $request );
-
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1344,49 +1344,6 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
-	 * Test that creating a published changeset with update_item() returns a new changeset UUID.
-	 */
-	public function test_update_item_create_has_next_changeset_id_after_publish() {
-		wp_set_current_user( self::$admin_id );
-
-		$uuid_before = wp_generate_uuid4();
-
-		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid_before ) );
-		$request->set_body_params( array(
-			'status' => 'publish',
-		) );
-		$response = $this->server->dispatch( $request );
-
-		$data = $response->get_data();
-		$this->assertTrue( isset( $data['next_changeset_uuid'] ) );
-		$this->assertNotSame( $data['next_changeset_uuid'], $uuid_before );
-	}
-
-	/**
-	 * Test that publishing an existing changeset with update_item() returns a new changeset UUID.
-	 */
-	public function test_update_item_edit_has_next_changeset_id_after_publish() {
-		wp_set_current_user( self::$admin_id );
-
-		$uuid_before = wp_generate_uuid4();
-
-		$manager = new WP_Customize_Manager( array(
-			'changeset_uuid' => $uuid_before,
-		) );
-		$manager->save_changeset_post();
-
-		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid_before ) );
-		$request->set_body_params( array(
-			'status' => 'publish',
-		) );
-		$response = $this->server->dispatch( $request );
-
-		$data = $response->get_data();
-		$this->assertTrue( isset( $data['next_changeset_uuid'] ) );
-		$this->assertNotSame( $data['next_changeset_uuid'], $uuid_before );
-	}
-
-	/**
 	 * Test that creating a published changeset with update_item() updates a valid setting.
 	 */
 	public function test_update_item_create_with_bloginfo() {

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -856,8 +856,8 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function data_bad_customize_changeset_status() {
 		return array(
-			// Doesn't exist.
-			array( rand_str() ),
+			// Probably doesn't exist.
+			array( '437284923487239847293487' ),
 			// Not in the whitelist.
 			array( 'trash' ),
 		);
@@ -1374,7 +1374,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		wp_set_current_user( self::$admin_id );
 
 		$uuid = wp_generate_uuid4();
-		$blogname_after = rand_str();
+		$blogname_after = 'test_update_item_create_with_bloginfo';
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
@@ -1397,7 +1397,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_update_item_edit_with_bloginfo() {
 		wp_set_current_user( self::$admin_id );
 
-		$blogname_after = rand_str();
+		$blogname_after = 'test_update_item_edit_with_bloginfo';
 
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
@@ -1424,7 +1424,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_update_item_setting_validities() {
 		wp_set_current_user( self::$admin_id );
 
-		$bad_setting = rand_str();
+		$bad_setting = 'test_update_item_setting_validities';
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', wp_generate_uuid4() ) );
 		$request->set_body_params( array(
@@ -1456,7 +1456,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
-				'blogname' => rand_str(),
+				'blogname' => 'test_update_item_insert_transaction_fail_setting_validities',
 				$illegal_setting => array(
 					'value' => 'Foo',
 				),
@@ -1481,7 +1481,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_update_item_update_transaction_fail_setting_validities() {
 		wp_set_current_user( self::$admin_id );
 
-		$blogname_before = rand_str();
+		$blogname_before = 'test_update_item_update_transaction_fail_setting_validities';
 
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
@@ -1498,7 +1498,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
-				'blogname' => rand_str(),
+				'blogname' => $blogname_before . '_updated',
 				$illegal_setting => array(
 					'value' => 'Foo',
 				),

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -110,8 +110,6 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
-
-	/**
 	 * Test that changesets cannot be created with update_item() when the user lacks capabilities.
 	 */
 	public function test_update_item_cannot_create_changeset_post() {

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -129,7 +129,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Test getting changeset without having proper permissions.
 	 */
-	public function test_get_changeset_without_permissions() {
+	public function test_get_item_without_permissions() {
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
@@ -143,7 +143,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Test getting changeset with invalid UUID.
 	 */
-	public function test_get_changeset_with_invalid_uuid() {
+	public function test_get_item_with_invalid_uuid() {
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
@@ -154,7 +154,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Test getting changeset list with edit context with proper permissions.
 	 */
-	public function test_get_changeset_list_context_with_permission() {
+	public function test_get_item_list_context_with_permission() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/changesets' );
 		$request->set_query_params( array(
@@ -169,7 +169,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Test getting changeset list with edit context without proper permissions.
 	 */
-	public function test_get_changeset_list_context_without_permission() {
+	public function test_get_item_list_context_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/changesets' );
 		$request->set_query_params( array(
@@ -183,7 +183,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Test getting a changeset with edit context without proper permissions.
 	 */
-	public function test_get_changeset_context_without_permission() {
+	public function test_get_item_context_without_permission() {
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
@@ -219,6 +219,13 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
+	 * Test the case when user doesn't have permissions for some of the settings.
+	 */
+	public function test_get_item_without_permissions_to_some_settings() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Test create_item.
 	 *
 	 * @covers WP_REST_Customize_Changesets_Controller::create_item()
@@ -233,6 +240,13 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::update_item()
 	 */
 	public function test_update_item() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test the case when the user doesn't have permissions to edit some of the settings within the changeset.
+	 */
+	public function test_update_item_cannot_edit_some_settings() {
 		$this->markTestIncomplete();
 	}
 
@@ -253,7 +267,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'cannot_change_changeset_slug', $response, 403 );
+		$this->assertErrorResponse( 'cannot_edit_changeset_slug', $response, 403 );
 		$this->assertSame( get_post( $manager->changeset_post_id() )->post_name, $manager->changeset_uuid() );
 	}
 

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -154,7 +154,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['status']['arg_options'] );
 
 		$this->assertArrayHasKey( 'title', $properties );
-		$this->assertSame( 'string', $properties['title']['type'] );
+		$this->assertSame( 'object', $properties['title']['type'] );
 		$this->assertArrayHasKey( 'sanitize_callback', $properties['title']['arg_options'] );
 	}
 
@@ -321,6 +321,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		add_action( 'customize_register', array( $this, 'add_test_customize_settings' ) );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', $uuid ) );
+
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -338,17 +339,17 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Filter for GET request.
 	 *
-	 * @param object $response Rest response.
-	 * @return object mixed Filtered data.
+	 * @param array $data Response data.
+	 * @return array Filtered data.
 	 */
-	public function get_changeset_custom_callback( $response ) {
-		$response->data['settings'] = array(
+	public function get_changeset_custom_callback( $data ) {
+		$data['settings'] = array(
 			'foo' => array(
 				'value' => 'bar',
 			),
 		);
 
-		return $response;
+		return $data;
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -480,7 +480,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
-	 * Test that choosing a custom slug is frobidden.
+	 * Test that choosing a custom slug is forbidden.
 	 */
 	public function test_create_item_try_custom_slug() {
 		wp_set_current_user( self::$admin_id );
@@ -1096,7 +1096,10 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertSame( $this_year, date( 'Y', strtotime( $data['date_gmt'] ) ) );
 
 		$manager = new WP_Customize_Manager();
-		$this->assertSame( $this_year, date( 'Y', strtotime( $manager->find_changeset_post_id( $uuid )->post_date_gmt ) ) );
+		$post_id = $manager->find_changeset_post_id( $uuid );
+		$this->assertInternalType( 'int', $post_id );
+		$changeset_post = get_post( $post_id );
+		$this->assertSame( $this_year, date( 'Y', strtotime( $changeset_post->post_date_gmt ) ) );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -137,6 +137,8 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::get_item()
 	 */
 	public function test_get_item() {
+		wp_set_current_user( self::$admin_id );
+
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -209,7 +209,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertSame( $data['title'], $title_after );
@@ -305,7 +305,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertSame( $data['date_gmt'], $date_after );

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -447,7 +447,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+		$this->assertErrorResponse( 'rest_cannot_create', $response, 403 );
 	}
 
 	/**
@@ -486,7 +486,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$request->set_param( 'status', $bad_status );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'bad_customize_changeset_status', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
 	/**
@@ -506,7 +506,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			),
 		) );
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+		$this->assertErrorResponse( 'rest_cannot_create', $response, 403 );
 		$user->remove_cap( 'edit_theme_options' );
 	}
 
@@ -517,10 +517,10 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		wp_set_current_user( self::$admin_id );
 
 		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
-		$request->set_param( 'name', 'slug' );
+		$request->set_param( 'slug', 'slug' );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'invalid_customize_changeset_data', $response, 400 );
+		$this->assertErrorResponse( 'cannot_edit_changeset_slug', $response, 400 );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -80,8 +80,8 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wp/v2/customize/changesets', $routes );
-		$this->assertArrayHasKey( '/wp/v2/customize/changesets/(?P<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}+)', $routes );
+		$this->assertArrayHasKey( '/customize/v1/changesets', $routes );
+		$this->assertArrayHasKey( '/customize/v1/changesets/(?P<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}+)', $routes );
 	}
 
 	/**
@@ -92,7 +92,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_context_param() {
 
 		// Test collection.
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'OPTIONS', '/customize/v1/changesets' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
@@ -101,7 +101,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		// Test single.
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/customize/changesets/' . $manager->changeset_uuid() );
+		$request = new WP_REST_Request( 'OPTIONS', '/customize/v1/changesets/' . $manager->changeset_uuid() );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
@@ -116,16 +116,17 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_get_item_schema() {
 
 		// @todo Add all properties.
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'OPTIONS', '/customize/v1/changesets' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 6, count( $properties ) );
+		$this->assertEquals( 7, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
 		$this->assertArrayHasKey( 'date_gmt', $properties );
 		$this->assertArrayHasKey( 'settings', $properties ); // Instead of content.
+		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 	}
@@ -139,7 +140,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -156,7 +157,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -167,7 +168,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_with_invalid_uuid() {
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_changeset_invalid_uuid', $response, 404 );
@@ -178,7 +179,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_list_context_with_permission() {
 		wp_set_current_user( self::$admin_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'GET', '/customize/v1/changesets' );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -193,7 +194,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_list_context_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'GET', '/customize/v1/changesets' );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -210,7 +211,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -225,7 +226,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::get_items()
 	 */
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets' ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets' ) );
 		$response = $this->server->dispatch( $request );
 
 		$manager1 = new WP_Customize_Manager();
@@ -271,7 +272,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			),
 		) );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -319,7 +320,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 		$changeset_data = $response->get_data();
 
@@ -346,7 +347,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_invalid_data() {
 		wp_set_current_user( self::$editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_body_params( array(
 			'customize_changeset_data' => '[MALFORMED]',
 		) );
@@ -361,7 +362,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_as_editor() {
 		wp_set_current_user( self::$editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'foo' => array(
@@ -386,7 +387,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_body_params( array(
 			'title' => 'Title',
 		) );
@@ -401,7 +402,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_already_published() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_param( 'status', 'publish' );
 
 		$response = $this->server->dispatch( $request );
@@ -417,7 +418,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_invalid_status( $bad_status ) {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_param( 'status', $bad_status );
 
 		$response = $this->server->dispatch( $request );
@@ -432,7 +433,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$user = new WP_User( self::$editor_id );
 		$user->remove_cap( 'edit_theme_options' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'title' => array(
@@ -451,7 +452,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_try_custom_slug() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_param( 'name', 'slug' );
 
 		$response = $this->server->dispatch( $request );
@@ -464,7 +465,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_with_existing_post_id() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 
 		$request->set_param( 'id', 1 );
 		$response = $this->server->dispatch( $request );
@@ -480,7 +481,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$menu_id = wp_create_nav_menu( 'menu' );
 		$menu_item_id = wp_update_nav_menu_item( $menu_id, 0 );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
+		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 
 		$args = array(
 			'menu-item-object-id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
@@ -541,7 +542,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		add_filter( 'rest_pre_update_changeset', array( $this, 'update_changeset_custom_callback' ), 10, 4 );
 
 		$title_after = 'Title after';
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_param( 'title', $title_after );
 		$request->set_param( 'status', 'draft' );
 
@@ -587,7 +588,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 
 		$changed_value = 'changed_setting_value';
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				$setting_forbidden_id => array(
@@ -601,7 +602,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			$setting_allowed_id => array(
 				'value' => $changed_value,
@@ -627,7 +628,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$uuid = wp_generate_uuid4();
 		$bad_slug = 'slug-after';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'slug' => $bad_slug,
 		) );
@@ -650,7 +651,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$bad_slug = 'slug-after';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'slug' => $bad_slug,
 		) );
@@ -668,7 +669,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -696,7 +697,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$content_before = get_post( $changeset_post_id )->post_content;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -728,7 +729,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$content_before = get_post( $changeset_post_id )->post_content;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => '[MALFORMED]',
 		) );
@@ -749,7 +750,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$uuid = wp_generate_uuid4();
 		$title = 'FooBarBaz';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'title' => $title,
 		) );
@@ -778,7 +779,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			'title' => $title_before,
 		) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'title' => $title_after,
 		) );
@@ -803,7 +804,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'status' => $bad_status,
 		) );
@@ -829,7 +830,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 		$status_before = get_post_status( $manager->changeset_post_id() );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $bad_status,
 		) );
@@ -864,7 +865,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'status' => $publish_status,
 		) );
@@ -891,7 +892,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 		$status_before = get_post_status( $manager->changeset_post_id() );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $publish_status,
 		) );
@@ -933,7 +934,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$changeset_data_before = $manager->changeset_data();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -966,7 +967,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$uuid = wp_generate_uuid4();
 		$date_gmt = date( 'Y-m-d H:i:s', ( time() + YEAR_IN_SECONDS ) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => $date_gmt,
 			'status' => 'draft',
@@ -994,7 +995,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
 		$date_after = date( 'Y-m-d H:i:s', ( strtotime( $date_before ) + YEAR_IN_SECONDS ) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => $date_after,
 			'status' => 'draft',
@@ -1024,7 +1025,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$status_after = 'draft';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $status_after,
 		) );
@@ -1051,7 +1052,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$status_after = 'future';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $status_after,
 		) );
@@ -1076,7 +1077,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			'status' => 'future',
 		) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1098,7 +1099,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '-1 week' ),
 		) );
@@ -1121,7 +1122,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '-1 week' ),
 		) );
@@ -1144,7 +1145,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$status_before = get_post_status( $manager->changeset_post_id() );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'future',
 		) );
@@ -1162,7 +1163,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '+1 week' ),
 		) );
@@ -1186,7 +1187,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$status_before = get_post_type( $manager->changeset_post_id() );
 		$this->assertSame( 'auto-draft', $status_before );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '+1 week' ),
 		) );
@@ -1204,7 +1205,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => 'BAD DATE',
 		) );
@@ -1227,7 +1228,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => 'BAD DATE',
 		) );
@@ -1250,7 +1251,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1273,7 +1274,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid_before ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid_before ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1301,7 +1302,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			),
 		) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1319,7 +1320,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$bad_setting = rand_str();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', wp_generate_uuid4() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', wp_generate_uuid4() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				$bad_setting => array(
@@ -1346,7 +1347,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				$illegal_setting => array(
@@ -1373,7 +1374,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'draft',
 		) );
@@ -1406,7 +1407,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_param( 'force', false );
 		$response = $this->server->dispatch( $request );
 
@@ -1436,7 +1437,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_param( 'force', false );
 		$response = $this->server->dispatch( $request );
 
@@ -1462,7 +1463,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 
@@ -1494,7 +1495,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 
@@ -1518,7 +1519,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_param( 'force', false );
 
 		$response = $this->server->dispatch( $request );
@@ -1543,7 +1544,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		wp_trash_post( $changeset_id );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
@@ -1554,7 +1555,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_delete_item_invalid_id() {
 		wp_set_current_user( self::$admin_id );
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', wp_generate_uuid4() ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', wp_generate_uuid4() ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
 	}
@@ -1564,7 +1565,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_delete_item_invalid_id_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', wp_generate_uuid4() ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', wp_generate_uuid4() ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 	}

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -92,7 +92,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_context_param() {
 
 		// Test collection.
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/customize/changesets' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
@@ -101,7 +101,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		// Test single.
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/changesets/' . $manager->changeset_uuid() );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/customize/changesets/' . $manager->changeset_uuid() );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( 'view', $data['endpoints'][0]['args']['context']['default'] );
@@ -116,7 +116,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_get_item_schema() {
 
 		// @todo Add all properties.
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/customize/changesets' );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
@@ -139,7 +139,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -156,7 +156,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
@@ -167,7 +167,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_with_invalid_uuid() {
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_changeset_invalid_uuid', $response, 404 );
@@ -178,7 +178,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_list_context_with_permission() {
 		wp_set_current_user( self::$admin_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/customize/changesets' );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -193,7 +193,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_get_item_list_context_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/customize/changesets' );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -210,7 +210,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_query_params( array(
 			'context' => 'edit',
 		) );
@@ -225,7 +225,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::get_items()
 	 */
 	public function test_get_items() {
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets' ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets' ) );
 		$response = $this->server->dispatch( $request );
 
 		$manager1 = new WP_Customize_Manager();
@@ -271,7 +271,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			),
 		) );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $response );
@@ -319,7 +319,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$response = $this->server->dispatch( $request );
 		$changeset_data = $response->get_data();
 
@@ -346,7 +346,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_invalid_data() {
 		wp_set_current_user( self::$editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_body_params( array(
 			'customize_changeset_data' => '[MALFORMED]',
 		) );
@@ -361,7 +361,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_as_editor() {
 		wp_set_current_user( self::$editor_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'foo' => array(
@@ -386,7 +386,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_body_params( array(
 			'title' => 'Title',
 		) );
@@ -401,7 +401,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_already_published() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_param( 'status', 'publish' );
 
 		$response = $this->server->dispatch( $request );
@@ -417,7 +417,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_invalid_status( $bad_status ) {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_param( 'status', $bad_status );
 
 		$response = $this->server->dispatch( $request );
@@ -432,7 +432,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$user = new WP_User( self::$editor_id );
 		$user->remove_cap( 'edit_theme_options' );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'title' => array(
@@ -451,7 +451,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_try_custom_slug() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 		$request->set_param( 'name', 'slug' );
 
 		$response = $this->server->dispatch( $request );
@@ -464,7 +464,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_create_item_with_existing_post_id() {
 		wp_set_current_user( self::$admin_id );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 
 		$request->set_param( 'id', 1 );
 		$response = $this->server->dispatch( $request );
@@ -480,7 +480,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$menu_id = wp_create_nav_menu( 'menu' );
 		$menu_item_id = wp_update_nav_menu_item( $menu_id, 0 );
 
-		$request = new WP_REST_Request( 'POST', '/wp/v2/changesets' );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/customize/changesets' );
 
 		$args = array(
 			'menu-item-object-id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
@@ -541,7 +541,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		add_filter( 'rest_pre_update_changeset', array( $this, 'update_changeset_custom_callback' ), 10, 4 );
 
 		$title_after = 'Title after';
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_param( 'title', $title_after );
 		$request->set_param( 'status', 'draft' );
 
@@ -587,7 +587,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 
 		$changed_value = 'changed_setting_value';
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				$setting_forbidden_id => array(
@@ -601,7 +601,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			$setting_allowed_id => array(
 				'value' => $changed_value,
@@ -627,7 +627,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$uuid = wp_generate_uuid4();
 		$bad_slug = 'slug-after';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'slug' => $bad_slug,
 		) );
@@ -650,7 +650,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$bad_slug = 'slug-after';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'slug' => $bad_slug,
 		) );
@@ -668,7 +668,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -696,7 +696,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$content_before = get_post( $changeset_post_id )->post_content;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -728,7 +728,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$content_before = get_post( $changeset_post_id )->post_content;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => '[MALFORMED]',
 		) );
@@ -749,7 +749,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$uuid = wp_generate_uuid4();
 		$title = 'FooBarBaz';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'title' => $title,
 		) );
@@ -778,7 +778,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			'title' => $title_before,
 		) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'title' => $title_after,
 		) );
@@ -803,7 +803,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'status' => $bad_status,
 		) );
@@ -829,7 +829,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 		$status_before = get_post_status( $manager->changeset_post_id() );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $bad_status,
 		) );
@@ -864,7 +864,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'status' => $publish_status,
 		) );
@@ -891,7 +891,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager->save_changeset_post();
 		$status_before = get_post_status( $manager->changeset_post_id() );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $publish_status,
 		) );
@@ -933,7 +933,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$changeset_data_before = $manager->changeset_data();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -966,7 +966,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$uuid = wp_generate_uuid4();
 		$date_gmt = date( 'Y-m-d H:i:s', ( time() + YEAR_IN_SECONDS ) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => $date_gmt,
 			'status' => 'draft',
@@ -994,7 +994,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
 		$date_after = date( 'Y-m-d H:i:s', ( strtotime( $date_before ) + YEAR_IN_SECONDS ) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => $date_after,
 			'status' => 'draft',
@@ -1024,7 +1024,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$status_after = 'draft';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $status_after,
 		) );
@@ -1051,7 +1051,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$status_after = 'future';
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => $status_after,
 		) );
@@ -1076,7 +1076,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			'status' => 'future',
 		) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1098,7 +1098,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '-1 week' ),
 		) );
@@ -1121,7 +1121,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '-1 week' ),
 		) );
@@ -1144,7 +1144,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$status_before = get_post_status( $manager->changeset_post_id() );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'future',
 		) );
@@ -1162,7 +1162,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '+1 week' ),
 		) );
@@ -1186,7 +1186,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$status_before = get_post_type( $manager->changeset_post_id() );
 		$this->assertSame( 'auto-draft', $status_before );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => strtotime( '+1 week' ),
 		) );
@@ -1204,7 +1204,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$uuid = wp_generate_uuid4();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
 			'date_gmt' => 'BAD DATE',
 		) );
@@ -1227,7 +1227,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$date_before = get_post( $manager->changeset_post_id() )->post_date_gmt;
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'date_gmt' => 'BAD DATE',
 		) );
@@ -1250,7 +1250,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1273,7 +1273,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$manager->save_changeset_post();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid_before ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $uuid_before ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1301,7 +1301,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			),
 		) );
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'publish',
 		) );
@@ -1319,7 +1319,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$bad_setting = rand_str();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', wp_generate_uuid4() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', wp_generate_uuid4() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				$bad_setting => array(
@@ -1346,7 +1346,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'customize_changeset_data' => array(
 				$illegal_setting => array(
@@ -1373,7 +1373,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager();
 
-		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/customize/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
 			'status' => 'draft',
 		) );
@@ -1406,7 +1406,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_param( 'force', false );
 		$response = $this->server->dispatch( $request );
 
@@ -1436,7 +1436,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_param( 'force', false );
 		$response = $this->server->dispatch( $request );
 
@@ -1462,7 +1462,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 
@@ -1494,7 +1494,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 
@@ -1518,7 +1518,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$manager = new WP_Customize_Manager();
 		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$request->set_param( 'force', false );
 
 		$response = $this->server->dispatch( $request );
@@ -1543,7 +1543,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		wp_trash_post( $changeset_id );
 
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', $uuid ) );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
@@ -1554,7 +1554,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_delete_item_invalid_id() {
 		wp_set_current_user( self::$admin_id );
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', wp_generate_uuid4() ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', wp_generate_uuid4() ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
 	}
@@ -1564,7 +1564,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 */
 	public function test_delete_item_invalid_id_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/changesets/%s', wp_generate_uuid4() ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/wp/v2/customize/changesets/%s', wp_generate_uuid4() ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 	}

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -146,7 +146,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertNotInstanceOf( 'WP_Error', $response );
 		$response = rest_ensure_response( $response );
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 1, count( $response->get_data() ) );
+		$this->assertSame( $manager->changeset_uuid(), $response->get_data()['slug'] );
 	}
 
 	/**
@@ -171,7 +171,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$request = new WP_REST_Request( 'GET', sprintf( '/customize/v1/changesets/%s', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_changeset_invalid_uuid', $response, 404 );
+		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -345,6 +345,8 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 			$this->markTestSkipped( 'Changesets are not trashed when revisions are enabled.' );
 		}
 	}
+
+	/**
 	 * Test delete_item.
 	 *
 	 * @covers WP_REST_Customize_Changesets_Controller::delete_item()

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -449,7 +449,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertSame( $data['title'], $title_after );
+		$this->assertSame( $data['title'], $title );
 
 		$manager = new WP_Customize_Manager();
 		$this->assertSame( get_post( $manager->find_changeset_post_id( $uuid ) )->post_title, $title );
@@ -605,6 +605,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Test that update_item() rejects updating a published changeset.
 	 *
+	 * @param string $published_status Published status.
 	 * @dataProvider data_published_changeset_status
 	 */
 	public function test_update_item_changeset_already_published( $published_status ) {
@@ -653,7 +654,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		wp_set_current_user( self::$admin_id );
 
 		$uuid = wp_generate_uuid4();
-		$date_gmt = date( 'Y-m-d H:i:s', ( strtotime( $date_before ) + YEAR_IN_SECONDS ) );
+		$date_gmt = date( 'Y-m-d H:i:s', ( time() + YEAR_IN_SECONDS ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $uuid ) );
 		$request->set_body_params( array(

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1074,7 +1074,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
-			'date_gmt' => ( strotime( $this_year ) + YEAR_IN_SECONDS ),
+			'date_gmt' => ( strtotime( $this_year ) + YEAR_IN_SECONDS ),
 			'status' => 'publish',
 		) );
 		$response = $this->server->dispatch( $request );

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1454,10 +1454,13 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertSame( 200, $response->get_status() );
+		$this->assertErrorResponse( 'invalid_customize_changeset_data', $response );
 
-		$data = $response->get_data();
-		$this->assertTrue( isset( $data['setting_validities'][ $bad_setting ]['unrecognized'] ) );
+		$error_data = $response->as_error()->get_error_data();
+		$this->assertTrue( isset( $error_data['setting_validities'][ $bad_setting ]['unrecognized'] ) );
+
+		$manager = new WP_Customize_Manager();
+		$this->assertEmpty( $manager->find_changeset_post_id( $uuid ) );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -461,7 +461,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_update_item_changeset_already_published( $published_status ) {
 		wp_set_current_user( self::$admin_id );
 
-		$manager = new WP_Customize_Manager;
+		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
 			'customize_changeset_data' => array(
 				'basic_option' => array(
@@ -557,7 +557,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$future_date = date( 'Y-m-d H:i:s', strtotime( '+1 year' ) );
 
-		$manager = new WP_Customize_Manager;
+		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
 			'date_gmt' => $future_date,
 			'status' => 'draft',
@@ -584,7 +584,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$this_year = date( 'Y' );
 
-		$manager = new WP_Customize_Manager;
+		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
 			'date_gmt' => ( strtotime( $this_year ) + YEAR_IN_SECONDS ),
 			'status' => 'future',
@@ -609,7 +609,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_update_item_not_future_date_with_future_status() {
 		wp_set_current_user( self::$admin_id );
 
-		$manager = new WP_Customize_Manager;
+		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
 			'date_gmt' => date( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
 		) );

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -12,6 +12,16 @@
  * @group restapi
  */
 class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controller_TestCase {
+
+	/**
+	 * REST Server.
+	 *
+	 * Note that this variable is already defined on the parent class but it lacks the phpdoc variable type.
+	 *
+	 * @var WP_REST_Server
+	 */
+	protected $server;
+
 	/**
 	 * Subscriber user ID.
 	 *

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -397,16 +397,26 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
-	 * Test creating an item with 'publish' status.
+	 * Test creating an item with 'publish' status. This should publish the changeset settings.
 	 */
 	public function test_create_item_already_published() {
 		wp_set_current_user( self::$admin_id );
 
 		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
 		$request->set_param( 'status', 'publish' );
+		$request->set_body_params( array(
+			'status' => 'publish',
+			'customize_changeset_data' => array(
+				'blogname' => array(
+					'value' => 'Blogname',
+				),
+			),
+		) );
 
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'bad_customize_changeset_status', $response, 400 );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertEquals( get_option( 'blogname' ), 'Blogname' );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -237,6 +237,27 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
+	 * Test that slug of a changeset cannot be updated.
+	 */
+	public function test_update_item_cannot_change_slug() {
+		wp_set_current_user( self::$admin_id );
+
+		$manager = new WP_Customize_Manager();
+		$slug_after = 'slug-after';
+
+		$manager->save_changeset_post();
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request->set_body_params( array(
+			'slug' => $slug_after,
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'cannot_change_changeset_slug', $response, 403 );
+		$this->assertSame( get_post( $manager->changeset_post_id() )->post_name, $manager->changeset_uuid() );
+	}
+
+	/**
 	 * Test that changesets cannot be created with update_item() when the user lacks capabilities.
 	 */
 	public function test_update_item_cannot_create_changeset_post() {

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -285,6 +285,13 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
+	 * Test getting item with filter applied.
+	 */
+	public function test_get_item_with_filter() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Test create_item.
 	 *
 	 * @covers WP_REST_Customize_Changesets_Controller::create_item()
@@ -303,10 +310,71 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
+	 * Test updating item with filter applied.
+	 */
+	public function test_update_item_with_filter() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Test the case when the user doesn't have permissions to edit some of the settings within the changeset.
 	 */
 	public function test_update_item_cannot_edit_some_settings() {
-		$this->markTestIncomplete();
+		$manager = new WP_Customize_Manager();
+		$setting_allowed_id = 'allowed_setting';
+		$setting_allowed = new WP_Customize_Setting( $manager, $setting_allowed_id );
+		$result_setting1 = $manager->add_setting( $setting_allowed );
+		$result_setting1->capability = 'editor_can_edit';
+
+		$setting_forbidden_id = 'forbidden_setting';
+		$setting_forbidden = new WP_Customize_Setting( $manager, $setting_forbidden_id );
+		$result_setting2 = $manager->add_setting( $setting_forbidden );
+		$result_setting2->capability = 'noone_can_edit';
+
+		wp_set_current_user( self::$editor_id );
+		$user = new WP_User( self::$editor_id );
+		$user->add_cap( 'editor_can_edit' );
+
+		$manager = new WP_Customize_Manager();
+		$manager->save_changeset_post( array(
+			'customize_changeset_data' => array(
+				$setting_allowed_id => array(
+					'value' => 'Foo',
+				),
+				$setting_forbidden_id => array(
+					'value' => 'Bar',
+				),
+			),
+		) );
+
+		$changed_value = 'changed_setting_value';
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request->set_body_params( array(
+			$setting_forbidden_id => array(
+				'value' => $changed_value,
+			),
+			$setting_allowed_id => array(
+				'value' => $changed_value,
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
+		$request->set_body_params( array(
+			$setting_allowed_id => array(
+				'value' => $changed_value,
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+		$response = rest_ensure_response( $response );
+
+		$changeset_data = $response->get_data();
+		$changeset_settings = json_decode( $changeset_data[0]['post_content'], true );
+
+		$this->assertSame( 'setting_value', $changeset_settings[ $setting_allowed_id ]['value'] );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1446,6 +1446,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 					'value' => 'Foo',
 				),
 			),
+			'status' => 'draft',
 		) );
 		$response = $this->server->dispatch( $request );
 

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -345,7 +345,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
-			'date' => $date_after,
+			'date_gmt' => $date_after,
 		) );
 		$response = $this->server->dispatch( $request );
 
@@ -366,7 +366,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager;
 		$manager->save_changeset_post( array(
-			'date' => $future_date,
+			'date_gmt' => $future_date,
 			'status' => 'future',
 		) );
 
@@ -393,7 +393,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager;
 		$manager->save_changeset_post( array(
-			'date' => $future_date,
+			'date_gmt' => $future_date,
 			'status' => 'draft',
 		) );
 
@@ -420,7 +420,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager;
 		$manager->save_changeset_post( array(
-			'date' => ( strtotime( $this_year ) + YEAR_IN_SECONDS ),
+			'date_gmt' => ( strtotime( $this_year ) + YEAR_IN_SECONDS ),
 			'status' => 'future',
 		) );
 
@@ -445,7 +445,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$manager = new WP_Customize_Manager;
 		$manager->save_changeset_post( array(
-			'date' => date( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
+			'date_gmt' => date( 'Y-m-d H:i:s', strtotime( '-1 year' ) ),
 		) );
 
 		$status_before = get_post_status( $manager->changeset_post_id() );
@@ -475,7 +475,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
-			'date' => 'BAD DATE',
+			'date_gmt' => 'BAD DATE',
 		) );
 		$response = $this->server->dispatch( $request );
 

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -223,7 +223,6 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	// @todo get items by author and other query params.
-
 	/**
 	 * Test get_items.
 	 *
@@ -569,20 +568,10 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * Test the case when the user doesn't have permissions to edit some of the settings within the changeset.
 	 */
 	public function test_update_item_cannot_edit_some_settings() {
-		$manager = new WP_Customize_Manager();
 		$setting_allowed_id = 'allowed_setting';
-		$setting_allowed = new WP_Customize_Setting( $manager, $setting_allowed_id );
-		$result_setting1 = $manager->add_setting( $setting_allowed );
-		$result_setting1->capability = 'editor_can_edit';
-
 		$setting_forbidden_id = 'forbidden_setting';
-		$setting_forbidden = new WP_Customize_Setting( $manager, $setting_forbidden_id );
-		$result_setting2 = $manager->add_setting( $setting_forbidden );
-		$result_setting2->capability = 'noone_can_edit';
 
-		wp_set_current_user( self::$editor_id );
-		$user = new WP_User( self::$editor_id );
-		$user->add_cap( 'editor_can_edit' );
+		wp_set_current_user( self::$admin_id );
 
 		$manager = new WP_Customize_Manager();
 		$manager->save_changeset_post( array(
@@ -595,6 +584,8 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 				),
 			),
 		) );
+
+		add_action( 'customize_register', array( $this, 'custom_settings_customize_register' ) );
 
 		$changed_value = 'changed_setting_value';
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
@@ -626,6 +617,8 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$changeset_settings = json_decode( $changeset_data['settings'], true );
 
 		$this->assertSame( 'setting_value', $changeset_settings[ $setting_allowed_id ]['value'] );
+
+		remove_action( 'customize_register', array( $this, 'custom_settings_customize_register' ) );
 	}
 
 	/**

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -23,8 +23,8 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function __construct() {
-		$this->namespace = 'wp/v2';
-		$this->rest_base = 'customize/changesets';
+		$this->namespace = 'customize/v1';
+		$this->rest_base = 'changesets';
 
 		// @todo meta?
 	}


### PR DESCRIPTION
Tests for the customize_changeset endpoint.

There are likely some missing and the tests need adjusting later.