### PR TITLE
Update endpoint for customize_changeset.

### DIFF
--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -701,19 +701,6 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	}
 
 	/**
-	 * Test that choosing a custom slug is forbidden.
-	 */
-	public function test_create_item_try_custom_slug() {
-		wp_set_current_user( self::$admin_id );
-
-		$request = new WP_REST_Request( 'POST', '/customize/v1/changesets' );
-		$request->set_param( 'slug', 'slug' );
-
-		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'cannot_edit_changeset_slug', $response, 403 );
-	}
-
-	/**
 	 * Test that create_item() rejects creating changesets with nonexistant and disallowed post statuses.
 	 *
 	 * @dataProvider data_bad_customize_changeset_status
@@ -1020,11 +1007,11 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $uuid ) );
 		$request->set_body_params( array(
-			'slug' => $bad_slug,
+			'uuid' => $bad_slug,
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'cannot_edit_changeset_slug', $response, 403 );
+		$this->assertErrorResponse( 'rest_incorrect_uuid', $response, 402 );
 
 		$manager = new WP_Customize_Manager();
 		$this->assertEmpty( get_post( $manager->find_changeset_post_id( $uuid ) ) );
@@ -1043,11 +1030,11 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_body_params( array(
-			'slug' => $bad_slug,
+			'uuid' => $bad_slug,
 		) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'cannot_edit_changeset_slug', $response, 403 );
+		$this->assertErrorResponse( 'rest_incorrect_uuid', $response, 402 );
 		$this->assertSame( get_post( $manager->changeset_post_id() )->post_name, $manager->changeset_uuid() );
 	}
 
@@ -1312,9 +1299,10 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertErrorResponse( 'rest_cannot_edit', $response );
 
 		$manager = new WP_Customize_Manager( array(
-			'uuid' => $uuid,
+			'changeset_uuid' => $uuid,
 		) );
-		$this->assertNull( $manager->changeset_post_id() );
+		$data = $manager->changeset_data();
+		$this->assertFalse( isset( $data['basic_option'] ) );
 	}
 
 	/**

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: WP_REST_Posts_Controller class
+ * REST API: WP_REST_Customize_Changesets_Controller class
  *
  * @package WordPress
  * @subpackage REST_API
@@ -8,7 +8,7 @@
  */
 
 /**
- * Core class to access posts via the REST API.
+ * Core class to access customize changesets via the REST API.
  *
  * @since ?.?.?
  *

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -66,8 +66,8 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	public function ensure_customize_manager( $changeset_uuid = null ) {
 		global $wp_customize;
 		if ( empty( $wp_customize ) || $wp_customize->changeset_uuid() !== $changeset_uuid ) {
-			$settings_preview = false;
-			$wp_customize = new \WP_Customize_Manager( compact( 'changeset_uuid', 'settings_preview' ) ); // WPCS: global override ok.
+			$settings_previewed = false;
+			$wp_customize = new \WP_Customize_Manager( compact( 'changeset_uuid', 'settings_previewed' ) ); // WPCS: global override ok.
 
 			/** This action is documented in wp-includes/class-wp-customize-manager.php */
 			do_action( 'customize_register', $wp_customize );
@@ -1120,8 +1120,8 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 * @return array|null|WP_Post Post object.
 	 */
 	protected function get_customize_changeset_post( $uuid ) {
-		$skip_setting_preview = true;
-		$customize_manager = new WP_Customize_Manager( compact( 'skip_setting_preview' ) );
+		$settings_previewed = true;
+		$customize_manager = new WP_Customize_Manager( compact( 'settings_previewed' ) );
 		$post = get_post( $customize_manager->find_changeset_post_id( $uuid ) );
 
 		return $post;

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -48,6 +48,10 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	public function __construct() {
 		$this->namespace = 'customize/v1';
 		$this->rest_base = 'changesets';
+
+		if ( ! class_exists( 'WP_Customize_Manager' ) ) {
+			require_once( ABSPATH . WPINC . '/class-wp-customize-manager.php' );
+		}
 	}
 
 	/**
@@ -60,7 +64,8 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	public function ensure_customize_manager( $changeset_uuid = null ) {
 		global $wp_customize;
 		if ( empty( $wp_customize ) || $wp_customize->changeset_uuid() !== $changeset_uuid ) {
-			$wp_customize = new WP_Customize_Manager( compact( 'changeset_uuid' ) ); // WPCS: global override ok.
+
+			$wp_customize = new \WP_Customize_Manager( compact( 'changeset_uuid' ) ); // WPCS: global override ok.
 
 			/** This action is documented in wp-includes/class-wp-customize-manager.php */
 			do_action( 'customize_register', $wp_customize );
@@ -1096,7 +1101,7 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 * @return array|null|WP_Post Post object.
 	 */
 	protected function get_customize_changeset_post( $uuid ) {
-		$customize_manager = new WP_Customize_manager();
+		$customize_manager = new WP_Customize_Manager();
 		return get_post( $customize_manager->find_changeset_post_id( $uuid ) );
 	}
 


### PR DESCRIPTION
The used param `WP_Customize_Manager::settings_previewed` is added with https://core.trac.wordpress.org/ticket/39221