### PR TITLE
Add DELETE endpoint

### DIFF
--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1747,7 +1747,7 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		wp_set_current_user( self::$subscriber_id );
 		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', wp_generate_uuid4() ) );
 		$response = $this->server->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
+		$this->assertErrorResponse( 'rest_post_invalid_uuid', $response, 404 );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1089,7 +1089,13 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 
 		$content_after = get_post( $changeset_post_id )->post_content;
-		$this->assertJsonStringEqualsJsonString( $content_before, $content_after );
+
+		// For PHP 5.2.
+		if ( method_exists( $this, 'assertJsonStringEqualsJsonString' ) ) {
+			$this->assertJsonStringEqualsJsonString( $content_before, $content_after );
+		} else {
+			$this->assertEquals( $content_before, $content_after );
+		}
 	}
 
 	/**
@@ -1117,7 +1123,13 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 		$this->assertErrorResponse( 'invalid_customize_changeset_data', $response, 400 );
 
 		$content_after = get_post( $changeset_post_id )->post_content;
-		$this->assertJsonStringEqualsJsonString( $content_before, $content_after );
+
+		// For PHP 5.2.
+		if ( method_exists( $this, 'assertJsonStringEqualsJsonString' ) ) {
+			$this->assertJsonStringEqualsJsonString( $content_before, $content_after );
+		} else {
+			$this->assertEquals( $content_before, $content_after );
+		}
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -1614,24 +1614,16 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	public function test_delete_item_without_permission() {
 		wp_set_current_user( self::$subscriber_id );
 
-		$uuid = wp_generate_uuid4();
-
-		$changeset_id = self::factory()->post->create( array(
-			'post_name' => $uuid,
-			'post_type' => 'customize_changeset',
-		) );
-
 		$manager = new WP_Customize_Manager();
+		$manager->save_changeset_post();
 
-		$this->assertSame( $changeset_id, $manager->find_changeset_post_id( $uuid ) );
-
-		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $uuid ) );
+		$request = new WP_REST_Request( 'DELETE', sprintf( '/customize/v1/changesets/%s', $manager->changeset_uuid() ) );
 		$request->set_param( 'force', false );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 
-		$this->assertNotSame( 'trash', get_post_status( $manager->find_changeset_post_id( $uuid ) ) );
+		$this->assertNotSame( 'trash', get_post_status( $manager->changeset_post_id() ) );
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -528,17 +528,19 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	/**
 	 * Filter for GET request.
 	 *
-	 * @param array $data Response data.
+	 * @param WP_REST_Response $response Response data.
 	 * @return array Filtered data.
 	 */
-	public function get_changeset_custom_callback( $data ) {
-		$data['settings'] = array(
-			'foo' => array(
-				'value' => 'bar',
+	public function get_changeset_custom_callback( $response ) {
+		$response->set_data( array(
+			'settings' => array(
+				'foo' => array(
+					'value' => 'bar',
+				),
 			),
-		);
+		) );
 
-		return $data;
+		return $response;
 	}
 
 	/**

--- a/tests/test-customize-changesets-controller.php
+++ b/tests/test-customize-changesets-controller.php
@@ -2157,6 +2157,30 @@ class WP_Test_REST_Customize_Changesets_Controller extends WP_Test_REST_Controll
 	 * @covers WP_REST_Customize_Changesets_Controller::prepare_item_for_response()
 	 */
 	public function test_prepare_item() {
-		$this->markTestIncomplete();
+		wp_set_current_user( self::$admin_id );
+		$uuid = wp_generate_uuid4();
+
+		$settings = wp_json_encode( array(
+			self::ALLOWED_TEST_SETTING_ID => array(
+				'value' => 'Foo',
+			),
+		) );
+
+		$customize_changeset = $this->factory()->post->create_and_get( array(
+			'post_type' => 'customize_changeset',
+			'post_name' => $uuid,
+			'post_status' => 'auto-draft',
+			'post_content' => $settings,
+		) );
+
+		$changeset_endpoint = new WP_REST_Customize_Changesets_Controller();
+		$request = new WP_REST_Request();
+
+		$response = $changeset_endpoint->prepare_item_for_response( $customize_changeset, $request );
+		$data = $response->get_data();
+
+		$this->assertSame( $uuid, $data['uuid'] );
+		$this->assertSame( 'auto-draft', $data['status'] );
+		$this->assertTrue( isset( $data['settings'][ self::ALLOWED_TEST_SETTING_ID ] ) );
 	}
 }

--- a/wp-api-customize-endpoints.php
+++ b/wp-api-customize-endpoints.php
@@ -71,7 +71,7 @@ function _wp_customize_trash_changeset( $post_id ) {
 		array(
 			'ID' => $post_id,
 		)
-	); // WPCS: db call ok
+	); // WPCS: db call ok.
 
 	clean_post_cache( $post_id );
 

--- a/wp-api-customize-endpoints.php
+++ b/wp-api-customize-endpoints.php
@@ -27,7 +27,7 @@
 /**
  * Init REST API endpoints for changesets.
  */
-function wp_api_customize_andpoints_rest_init() {
+function wp_api_customize_endpoints_rest_init() {
 
 	if ( ! class_exists( 'WP_REST_Customize_Changesets_Controller' ) ) {
 		require_once dirname( __FILE__ ) . '/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php';
@@ -35,6 +35,5 @@ function wp_api_customize_andpoints_rest_init() {
 
 	$changesets_controller = new WP_REST_Customize_Changesets_Controller();
 	$changesets_controller->register_routes();
-
 }
-add_action( 'rest_api_init', 'wp_api_customize_andpoints_rest_init' );
+add_action( 'rest_api_init', 'wp_api_customize_endpoints_rest_init' );

--- a/wp-api-customize-endpoints.php
+++ b/wp-api-customize-endpoints.php
@@ -37,3 +37,49 @@ function wp_api_customize_endpoints_rest_init() {
 	$changesets_controller->register_routes();
 }
 add_action( 'rest_api_init', 'wp_api_customize_endpoints_rest_init' );
+
+/**
+ * Temporary abstraction of changeset-trashing logic.
+ *
+ * @see https://github.com/WP-API/wp-api-customize-endpoints/pull/5#discussion_r120015044.
+ *
+ * @param $post_id Post ID.
+ */
+function _wp_customize_trash_changeset( $post_id ) {
+	global $wpdb;
+
+	$post = get_post( $post_id );
+
+	if ( ! $post ) {
+		return;
+	}
+
+	/** This action is documented in wp-includes/post.php */
+	do_action( 'wp_trash_post', $post_id );
+
+	add_post_meta( $post_id, '_wp_trash_meta_status', $post->post_status );
+	add_post_meta( $post_id, '_wp_trash_meta_time', time() );
+
+	$old_status = $post->post_status;
+	$new_status = 'trash';
+	$wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'ID' => $post_id ) );
+	clean_post_cache( $post_id );
+
+	$post->post_status = $new_status;
+	wp_transition_post_status( $new_status, $old_status, $post );
+
+	/** This action is documented in wp-includes/post.php */
+	do_action( 'edit_post', $post_id, $post );
+
+	/** This action is documented in wp-includes/post.php */
+	do_action( "save_post_{$post->post_type}", $post_id, $post, true );
+
+	/** This action is documented in wp-includes/post.php */
+	do_action( 'save_post', $post_id, $post, true );
+
+	/** This action is documented in wp-includes/post.php */
+	do_action( 'wp_insert_post', $post_id, $post, true );
+
+	/** This action is documented in wp-includes/post.php */
+	do_action( 'trashed_post', $post_id );
+}

--- a/wp-api-customize-endpoints.php
+++ b/wp-api-customize-endpoints.php
@@ -43,7 +43,7 @@ add_action( 'rest_api_init', 'wp_api_customize_endpoints_rest_init' );
  *
  * @see https://github.com/WP-API/wp-api-customize-endpoints/pull/5#discussion_r120015044.
  *
- * @param $post_id Post ID.
+ * @param int $post_id Post ID.
  */
 function _wp_customize_trash_changeset( $post_id ) {
 	global $wpdb;
@@ -62,7 +62,17 @@ function _wp_customize_trash_changeset( $post_id ) {
 
 	$old_status = $post->post_status;
 	$new_status = 'trash';
-	$wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'ID' => $post_id ) );
+
+	$wpdb->update(
+		$wpdb->posts,
+		array(
+			'post_status' => $new_status,
+		),
+		array(
+			'ID' => $post_id,
+		)
+	); // WPCS: db call ok
+
 	clean_post_cache( $post_id );
 
 	$post->post_status = $new_status;

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -59,12 +59,14 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 */
 	public function ensure_customize_manager( $changeset_uuid = null ) {
 		global $wp_customize;
-		if ( empty( $wp_customize ) || $wp_customize->changeset_uuid() !== $changeset_uuid ) {
+
+		if ( ! ( $wp_customize instanceof WP_Customize_Manager ) || $wp_customize->changeset_uuid() !== $changeset_uuid ) {
 			$wp_customize = new WP_Customize_Manager( compact( 'changeset_uuid' ) ); // WPCS: global override ok.
 
 			/** This action is documented in wp-includes/class-wp-customize-manager.php */
 			do_action( 'customize_register', $wp_customize );
 		}
+
 		return $wp_customize;
 	}
 

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -164,6 +164,7 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 		if ( $request['force'] ) {
 			$previous = $this->prepare_item_for_response( $post, $request );
 
+			// TODO: At this point $wp_customize will no longer have up-to-date post data.
 			$result = wp_delete_post( $manager->changeset_post_id(), true );
 
 			if ( ! $result ) {

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -749,7 +749,12 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			}
 
 			$response = new WP_REST_Response();
-			$response->set_data( array( 'deleted' => true, 'previous' => $previous->get_data() ) );
+
+			$response->set_data( array(
+				'deleted' => true,
+				'previous' => $previous->get_data(),
+			) );
+
 			return $response;
 		}
 

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -94,4 +94,42 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 	}
+
+	/**
+	 * Check whether a request can delete the specified changeset.
+	 *
+	 * @since ?.?.?
+	 * @access public
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error True if the request has access to delete the item, otherwise false or WP_Error object.
+	 */
+	public function delete_item_permissions_check( $request ) {
+		// Will $wp_customize need to be globalized?
+		$wp_customize = new WP_Customize_Manager( array(
+			'changeset_uuid' => $request['uuid'],
+		) );
+
+		if ( ! $wp_customize->changeset_post_id() ) {
+			return new WP_Error(
+				'rest_post_invalid_uuid',
+				__( 'Invalid changeset UUID.' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		if ( ! current_user_can( 'delete_post', $wp_customize->changeset_post_id() ) ) {
+			return new WP_Error(
+				'rest_cannot_delete',
+				__( 'Sorry, you are not allowed to delete this item.' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		return true;
+	}
 }

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -1354,7 +1354,7 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 * @return string|WP_Error Date string or error.
 	 */
 	public function sanitize_datetime( $date ) {
-		if ( DateTime::createFromFormat( 'Y-m-d H:i:s', $date ) ) {
+		if ( $this->is_valid_date( $date ) ) {
 			if ( $date < get_gmt_from_date( date( 'Y-m-d H:i:s', time() ) ) ) {
 				return new WP_Error( 'rest_incorrect_date', __( 'Incorrect date, date cannot be in past.' ), array(
 					'status' => 402,

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -146,12 +146,9 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 * @return bool|WP_Error True if the request has access to delete the item, otherwise false or WP_Error object.
 	 */
 	public function delete_item_permissions_check( $request ) {
-		// Will $wp_customize need to be globalized?
-		$wp_customize = new WP_Customize_Manager( array(
-			'changeset_uuid' => $request['uuid'],
-		) );
+		$manager = $this->ensure_customize_manager( $request['uuid'] );
 
-		if ( ! $wp_customize->changeset_post_id() ) {
+		if ( ! $manager->changeset_post_id() ) {
 			return new WP_Error(
 				'rest_post_invalid_uuid',
 				__( 'Invalid changeset UUID.' ),

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -913,16 +913,18 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
 
+		$response = rest_ensure_response( $data );
+
 		/**
 		 * Filters the customize changeset data for a response.
 		 *
 		 * @since 4.?.?
 		 *
-		 * @param WP_REST_Response $response The response object.
-		 * @param WP_Post          $post     Customize Changeset Post object.
-		 * @param WP_REST_Request  $request  Request object.
+		 * @param WP_REST_Response $response       The response object.
+		 * @param WP_Post          $changeset_post Customize Changeset Post object.
+		 * @param WP_REST_Request  $request        Request object.
 		 */
-		return apply_filters( 'rest_prepare_customize_changeset', $data, $changeset_post, $request );
+		return apply_filters( 'rest_prepare_customize_changeset', $response, $changeset_post, $request );
 	}
 
 	/**

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -68,7 +68,7 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 
 		if ( ! ( $wp_customize instanceof WP_Customize_Manager ) || $wp_customize->changeset_uuid() !== $changeset_uuid ) {
 			$settings_previewed = false;
-			$wp_customize = new \WP_Customize_Manager( compact( 'changeset_uuid', 'settings_previewed' ) ); // WPCS: global override ok.
+			$wp_customize = new WP_Customize_Manager( compact( 'changeset_uuid', 'settings_previewed' ) ); // WPCS: global override ok.
 
 			/** This action is documented in wp-includes/class-wp-customize-manager.php */
 			do_action( 'customize_register', $wp_customize );

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -1038,6 +1038,5 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 				'status' => 402,
 			) );
 		}
->>>>>>> master
 	}
 }

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -697,8 +697,7 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// TODO: Use 'delete_post'.
-		if ( ! current_user_can( 'customize' ) ) {
+		if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->delete_post, $manager->changeset_post_id() ) ) {
 			return new WP_Error(
 				'rest_cannot_delete',
 				__( 'Sorry, you are not allowed to delete this item.' ),

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -161,7 +161,8 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( ! current_user_can( 'delete_post', $wp_customize->changeset_post_id() ) ) {
+		// TODO: Use 'delete_post'.
+		if ( ! current_user_can( 'customize' ) ) {
 			return new WP_Error(
 				'rest_cannot_delete',
 				__( 'Sorry, you are not allowed to delete this item.' ),

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -79,7 +79,6 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	 * @see register_rest_route()
 	 */
 	public function register_routes() {
-
 		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
@@ -134,6 +133,120 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
+	}
+
+	/**
+	 * Deletes a changeset.
+	 *
+	 * @since ?.?.?
+	 * @access public
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_item( $request ) {
+		global $wpdb;
+
+		$manager = $this->ensure_customize_manager( $request['uuid'] );
+
+		if ( ! $manager->changeset_post_id() ) {
+			return new WP_Error(
+				'rest_post_invalid_uuid',
+				__( 'Invalid changeset UUID.' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		$post = get_post( $manager->changeset_post_id() );
+
+		if ( $request['force'] ) {
+			$previous = $this->prepare_item_for_response( $post, $request );
+
+			$result = wp_delete_post( $manager->changeset_post_id(), true );
+
+			if ( ! $result ) {
+				return new WP_Error(
+					'rest_cannot_delete',
+					__( 'The post cannot be deleted.' ),
+					array(
+						'status' => 500,
+					)
+				);
+			}
+
+			$response = new WP_REST_Response();
+			$response->set_data( array( 'deleted' => true, 'previous' => $previous->get_data() ) );
+			return $response;
+		}
+
+		// TODO (?): Not filterable a la WP_REST_Posts_Controller.
+		if ( ! ( EMPTY_TRASH_DAYS > 0 ) ) {
+			return new WP_Error(
+				'rest_trash_not_supported',
+				__( 'The post does not support trashing. Set force=true to delete.' ),
+				array(
+					'status' => 501,
+				)
+			);
+		}
+
+		if ( 'trash' === get_post_status( $manager->changeset_post_id() ) ) {
+			return new WP_Error(
+				'rest_already_trashed',
+				__( 'The changeset has already been deleted.' ),
+				array(
+					'status' => 410,
+				)
+			);
+		}
+
+		// TODO: Ripped straight from _wp_customize_publish_changeset().
+
+		/** This action is documented in wp-includes/post.php */
+		do_action( 'wp_trash_post', $manager->changeset_post_id() );
+
+		add_post_meta( $manager->changeset_post_id(), '_wp_trash_meta_status', $post->post_status );
+		add_post_meta( $manager->changeset_post_id(), '_wp_trash_meta_time', time() );
+
+		$old_status = $post->post_status;
+		$new_status = 'trash';
+		$wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'ID' => $manager->changeset_post_id() ) );
+		clean_post_cache( $manager->changeset_post_id() );
+
+		$post->post_status = $new_status;
+		wp_transition_post_status( $new_status, $old_status, $post );
+
+		/** This action is documented in wp-includes/post.php */
+		do_action( 'edit_post', $manager->changeset_post_id(), $post );
+
+		/** This action is documented in wp-includes/post.php */
+		do_action( "save_post_{$post->post_type}", $manager->changeset_post_id(), $post, true );
+
+		/** This action is documented in wp-includes/post.php */
+		do_action( 'save_post', $manager->changeset_post_id(), $post, true );
+
+		/** This action is documented in wp-includes/post.php */
+		do_action( 'wp_insert_post', $manager->changeset_post_id(), $post, true );
+
+		/** This action is documented in wp-includes/post.php */
+		do_action( 'trashed_post', $manager->changeset_post_id() );
+
+		// TODO: At this point $wp_customize will no longer have up-to-date post data.
+		$result = get_post( $manager->changeset_post_id() );
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'rest_cannot_delete',
+				__( 'The post cannot be deleted.' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		return $this->prepare_item_for_response( $result, $request );
 	}
 
 	/**

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -628,41 +628,12 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// TODO: Ripped straight from _wp_customize_publish_changeset().
-
-		/** This action is documented in wp-includes/post.php */
-		do_action( 'wp_trash_post', $manager->changeset_post_id() );
-
-		add_post_meta( $manager->changeset_post_id(), '_wp_trash_meta_status', $post->post_status );
-		add_post_meta( $manager->changeset_post_id(), '_wp_trash_meta_time', time() );
-
-		$old_status = $post->post_status;
-		$new_status = 'trash';
-		$wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'ID' => $manager->changeset_post_id() ) );
-		clean_post_cache( $manager->changeset_post_id() );
-
-		$post->post_status = $new_status;
-		wp_transition_post_status( $new_status, $old_status, $post );
-
-		/** This action is documented in wp-includes/post.php */
-		do_action( 'edit_post', $manager->changeset_post_id(), $post );
-
-		/** This action is documented in wp-includes/post.php */
-		do_action( "save_post_{$post->post_type}", $manager->changeset_post_id(), $post, true );
-
-		/** This action is documented in wp-includes/post.php */
-		do_action( 'save_post', $manager->changeset_post_id(), $post, true );
-
-		/** This action is documented in wp-includes/post.php */
-		do_action( 'wp_insert_post', $manager->changeset_post_id(), $post, true );
-
-		/** This action is documented in wp-includes/post.php */
-		do_action( 'trashed_post', $manager->changeset_post_id() );
+		_wp_customize_trash_changeset( $manager->changeset_post_id() );
 
 		// TODO: At this point $wp_customize will no longer have up-to-date post data.
 		$result = get_post( $manager->changeset_post_id() );
 
-		if ( ! $result ) {
+		if ( ! $result || 'trash' !== get_post_status( $result ) ) {
 			return new WP_Error(
 				'rest_cannot_delete',
 				__( 'The post cannot be deleted.' ),

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -1223,7 +1223,7 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 
 		// Use the date if passed.
 		if ( isset( $date ) ) {
-			if ( DateTime::createFromFormat( 'Y-m-d H:i:s', $date ) ) {
+			if ( $this->is_valid_date( $date ) ) {
 				return $date;
 			} else {
 				return date( 'Y-m-d H:i:s', time() );
@@ -1235,10 +1235,27 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 			return null;
 		}
 
-		if ( DateTime::createFromFormat( 'Y-m-d H:i:s', $date_gmt ) ) {
+		if ( $this->is_valid_date( $date_gmt ) ) {
 			return $date_gmt;
 		} else {
 			return date( 'Y-m-d H:i:s', time() );
+		}
+	}
+
+	/**
+	 * Checks if date is valid.
+	 *
+	 * @param $date
+	 * @return bool|DateTime|string
+	 */
+	protected function is_valid_date( $date ) {
+		if ( method_exists( 'DateTime', 'createFromFormat' ) ) {
+			return DateTime::createFromFormat( 'Y-m-d H:i:s', $date );
+		} else {
+
+			// For 5 >= 5.2.0.
+			$date = new DateTime( $date );
+			return $date->format( 'Y-m-d H:i:s' );
 		}
 	}
 

--- a/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
+++ b/wp-includes/rest-api/endpoints/class-wp-rest-customize-changesets-controller.php
@@ -1245,8 +1245,8 @@ class WP_REST_Customize_Changesets_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if date is valid.
 	 *
-	 * @param $date
-	 * @return bool|DateTime|string
+	 * @param string $date Date string.
+	 * @return bool|DateTime|string Return DateTime | if succeeds.
 	 */
 	protected function is_valid_date( $date ) {
 		if ( method_exists( 'DateTime', 'createFromFormat' ) ) {


### PR DESCRIPTION
This adds `delete_item()` and `delete_item_permissions_check()` methods. There are a few (at least) pieces that will probably need to be refactored. They're marked with `TODO`s, but the highlights:

- The custom logic for trashing or deleting a changeset is currently copied from `_wp_customize_publish_changeset()`. There might be a need for a function or `WP_Customize_Manager` method to house that logic.

- On that topic, there are points within `delete_item()` at which the post data stored in the `$wp_customize` instance becomes outdated. A way to trash or delete posts within `WP_Customize_Manager` so that the properties can be updated (similar to what happens now at the end of `save_changeset_post()`) might help address that, if it needs to be.

- `current_user_can()` checks should eventually use the `delete_post` meta cap.