### PR TITLE
Rename PHPCS ruleset to standard filename; add default command args

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -1,3 +1,2 @@
 CHECK_SCOPE=changed-files
-PHPCS_RULESET_FILE=phpcs.ruleset.xml
 WPCS_BRANCH=develop

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,9 @@
 	<rule ref="WordPress">
 		<exclude name="WordPress.XSS.EscapeOutput"/>
 	</rule>
+	<arg value="s"/>
+	<arg name="extensions" value="php"/>
+	<file>.</file>
 
 	<!-- @todo These should not be required since the WordPress-VIP ruleset isn't being included. -->
 	<rule ref="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents">


### PR DESCRIPTION
See https://github.com/xwp/wp-dev-lib/pull/243